### PR TITLE
Preserve qlknn batch dimensions

### DIFF
--- a/fusion_surrogates/qlknn/qlknn_model.py
+++ b/fusion_surrogates/qlknn/qlknn_model.py
@@ -307,18 +307,19 @@ class QLKNNModel:
     Returns:
       A flux array.
     """
-    if targets.ndim != 2:
-      targets = jnp.reshape(targets, [-1, targets.shape[-1]])
     target_name = self._config.flux_map[flux_name]['target']
     denominator_name = self._config.flux_map[flux_name]['denominator']
     target_idx = self._config.target_names.index(target_name)
     if denominator_name is not None:
       denominator_idx = self._config.target_names.index(denominator_name)
       # We clip the leading flux to 0.
-      flux = targets[:, target_idx] * targets[:, denominator_idx].clip(0)
+      flux = (
+          targets[..., target_idx]
+          * jnp.clip(targets[..., denominator_idx], min=0)
+      )
     else:
       # We clip the leading flux to 0.
-      flux = targets[:, target_idx].clip(0)
+      flux = jnp.clip(targets[..., target_idx], min=0)
     return jnp.expand_dims(flux, axis=-1)
 
   def predict(self, inputs: jax.Array) -> dict[str, jax.Array]:

--- a/fusion_surrogates/qlknn/qlknn_model_test.py
+++ b/fusion_surrogates/qlknn/qlknn_model_test.py
@@ -60,20 +60,20 @@ class QlknnModelTest(parameterized.TestCase):
         jax.random.key(0), shape=batch_dims + (model.num_inputs,)
     )
     targets = model.predict_targets(inputs)
-    # Flattening the batch dims.
-    targets = targets.reshape(-1, model.num_targets)
     fluxes = model.predict(inputs)
 
     def _get_column(idx):
-      """Get a (B, 1) column from targets."""
-      return targets[:, idx][:, None]
+      """Get a (..., 1) column from targets."""
+      return targets[..., idx : idx + 1]
 
-    testing.assert_array_equal(fluxes['flux0'], _get_column(0).clip(0))
+    testing.assert_array_equal(fluxes['flux0'], jnp.clip(_get_column(0), min=0))
     testing.assert_array_equal(
-        fluxes['flux1'], _get_column(1) * _get_column(0).clip(0)
+        fluxes['flux1'],
+        _get_column(1) * jnp.clip(_get_column(0), min=0),
     )
     testing.assert_array_equal(
-        fluxes['flux2'], _get_column(2) * _get_column(0).clip(0)
+        fluxes['flux2'],
+        _get_column(2) * jnp.clip(_get_column(0), min=0),
     )
 
   def test_get_fluxes_from_targets(self):
@@ -81,25 +81,24 @@ class QlknnModelTest(parameterized.TestCase):
     config = qlknn_model_test_utils.get_test_model_config()
     model = qlknn_model.QLKNNModel(config=config)
     targets = jax.random.uniform(
-        jax.random.key(0), shape=(1, 10, model.num_targets)
+        jax.random.key(0), shape=(2, 3, model.num_targets)
     )
-    targets = targets.reshape(-1, model.num_targets)
 
     def _get_column(idx):
-      """Get a (B, 1) column from targets."""
-      return targets[:, idx][:, None]
+      """Get a (..., 1) column from targets."""
+      return targets[..., idx : idx + 1]
 
     testing.assert_array_equal(
         model.get_flux_from_targets(targets, 'flux0'),
-        _get_column(0).clip(0),
+        jnp.clip(_get_column(0), min=0),
     )
     testing.assert_array_equal(
         model.get_flux_from_targets(targets, 'flux1'),
-        _get_column(1) * _get_column(0).clip(0),
+        _get_column(1) * jnp.clip(_get_column(0), min=0),
     )
     testing.assert_array_equal(
         model.get_flux_from_targets(targets, 'flux2'),
-        _get_column(2) * _get_column(0).clip(0),
+        _get_column(2) * jnp.clip(_get_column(0), min=0),
     )
 
   @parameterized.named_parameters(

--- a/fusion_surrogates/qlknn/qlknn_model_test.py
+++ b/fusion_surrogates/qlknn/qlknn_model_test.py
@@ -80,6 +80,7 @@ class QlknnModelTest(parameterized.TestCase):
     """Tests that get_fluxes_from_targets outputs are computed as expected."""
     config = qlknn_model_test_utils.get_test_model_config()
     model = qlknn_model.QLKNNModel(config=config)
+    # Use two leading batch dimensions to catch unintended flattening.
     targets = jax.random.uniform(
         jax.random.key(0), shape=(2, 3, model.num_targets)
     )


### PR DESCRIPTION
Hi, 

While reading through the surrogate APIs, I noticed that `QLKNNModel.predict_targets()` preserves the input batch shape, but `QLKNNModel.predict()` did not. The inconsistency came from `get_flux_from_targets()`, which reshaped targets to 2D before computing fluxes and therefore flattened all leading batch dimensions.

I made some changes for it via removing that internal flattening step and compute the fluxes along the last axis only. This should make `QLKNNModel.predict()` preserve arbitrary leading batch dimensions, which is more consistent with `predict_targets()` and with the other model APIs in this package.

And I also intentionally updated a useful regression test case so that it uses two leading batch dimensions explicitly. This makes the shape preserving behavior clearer in the test and helps catch unintended flattening in the future.

PS: This change is intended to fix the output shape behavior only. It should not change the numerical flux definition itself, since the same target and denominator relations are still being used in the flux construction.

PPS, This PR was tested in Python 3.11: `93 passed`.