### PR TITLE
Update TGLFNN-UKAEA version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 [project.optional-dependencies]
 
 tglfnnukaea = [
-    "tglfnn_ukaea==0.1.0",
+    "tglfnn_ukaea==0.2.0",
 ]
 
 testing = [


### PR DESCRIPTION
Version 0.2.0 distributes the weights for the STEP version of the TGLFNN-UKAEA model.